### PR TITLE
Django change

### DIFF
--- a/livepreview/wagtail_hooks.py
+++ b/livepreview/wagtail_hooks.py
@@ -6,7 +6,12 @@ import shutil
 
 from django.conf import settings
 from django.conf.urls import url
-from django.templatetags.static import static
+try:
+    # Django 2
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+except ImportError:
+    # Django 3 
+    from django.templatetags.static import static
 from django.utils.html import format_html
 
 from wagtail.core import hooks

--- a/livepreview/wagtail_hooks.py
+++ b/livepreview/wagtail_hooks.py
@@ -7,7 +7,6 @@ import shutil
 from django.conf import settings
 from django.conf.urls import url
 from django.templatetags.static import static
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.utils.html import format_html
 
 from wagtail.core import hooks

--- a/livepreview/wagtail_hooks.py
+++ b/livepreview/wagtail_hooks.py
@@ -6,6 +6,7 @@ import shutil
 
 from django.conf import settings
 from django.conf.urls import url
+from django.templatetags.static import static
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.utils.html import format_html
 


### PR DESCRIPTION
There is a change in django:
`from django.contrib.staticfiles.templatetags.staticfiles import static`
is replaced with
`from django.templatetags.static import static`