### PR TITLE
Option to disable LIVEPREVIEW globally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ LIVEPREVIEW_SAVE_REVISION_COUNT = 10
 # If True, LIVEPREVIEW_TIMEOUT can be as low as 250ms.
 # If False, the minimum LIVEPREVIEW_TIMEOUT is 1000ms.
 LIVEPREVIEW_USE_FILE_RENDERING = True
+# Disable LIVEPREVIEW globally
+LIVEPREVIEW_DISABLED = True
 ```
 
 #### Model Settings

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,9 @@ There a few global settings you can apply::
 	# If True, LIVEPREVIEW_TIMEOUT can be as low as 250ms.
 	# If False, the minimum LIVEPREVIEW_TIMEOUT is 1000ms.
 	LIVEPREVIEW_USE_FILE_RENDERING = True
+	
+	# Disable LIVEPREVIEW globally
+	LIVEPREVIEW_DISABLED = True
 
 
 ==============

--- a/livepreview/wagtail_hooks.py
+++ b/livepreview/wagtail_hooks.py
@@ -91,3 +91,10 @@ def before_edit_page(request, page_class):
 # def before_live_preview_save(request, page):
 #     """Sample live preview hooks."""
 #     print(page.id)
+
+
+@hooks.register('before_edit_page')
+def before_edit_page(request, page_class):
+    # Disable Live Preview Globally
+    if getattr(settings, 'LIVEPREVIEW_DISABLED', False):
+        page_class.LIVEPREVIEW_DISABLED = True


### PR DESCRIPTION
A simple use case would be the need to disable LivePreview during site development. However, still want the package installed and configured for when the site is pushed to production and edits are made by end-users (clients).